### PR TITLE
Remove driver level PIO initialization

### DIFF
--- a/src/MAIN_NEMS.F90
+++ b/src/MAIN_NEMS.F90
@@ -66,14 +66,6 @@
        USE module_NEMS_Rusage,ONLY: NEMS_Rusage
 !
 !-----------------------------------------------------------------------
-!***  This module contains PIO initialization related routines.
-!-----------------------------------------------------------------------
-!
-#if defined PIO
-       USE shr_pio_mod, ONLY: shr_pio_init1
-#endif
-!
-!-----------------------------------------------------------------------
 !
       IMPLICIT NONE
 !
@@ -198,15 +190,6 @@
       call rusage%start(MPI_COMM_WORLD,PROCNAME,PROCNAME_LEN,RC)
       ! It is safe to ignore RC since rusage%is_valid will tell us if
       ! the start succeeded.
-!
-!-----------------------------------------------------------------------
-!***  Initialize PIO. 8 is the maximum number of component models
-!-----------------------------------------------------------------------
-!
-      COMM_WORLD = MPI_COMM_WORLD
-#if defined PIO
-      call shr_pio_init1(8, "pio_in", COMM_WORLD)
-#endif
 !
 !-----------------------------------------------------------------------
 !***  Set up the default log.


### PR DESCRIPTION
This PR aims to remove the modifications that was done previously to bring PIO initialization to NEMS driver. Since both CMEPS (https://github.com/hafs-community/CMEPS/pull/1) and CDEPS (https://github.com/hafs-community/CDEPS/pull/2) are modified to have component level PIO initialization, there is no need to keep those modifications in the NEMS level.

Tests:
- Full RTs were run without any problem and passed. 